### PR TITLE
Fix env in versioning

### DIFF
--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -26,7 +26,7 @@ const monoFont = Spline_Sans_Mono({
 
 export const metadata = {
   other: {
-    env: process.env.GIT_BRANCH,
+    env: process.env.BUILD_ENV ||process.env.GIT_BRANCH,
     version: [process.env.GIT_COMMIT_TAG, process.env.GIT_COMMIT_HASH, process.env.GIT_COMMIT_DATE]
       .filter(Boolean)
       .join(' - '),


### PR DESCRIPTION
Vercel build cannot get the branch name, it will always be `master`
![image](https://github.com/lethang7794/project-blog/assets/58852251/41b2a1ba-a868-44f2-98d0-2f199ea6cbc2)
